### PR TITLE
add import use case

### DIFF
--- a/implementations/2/README.md
+++ b/implementations/2/README.md
@@ -29,3 +29,8 @@ Payload elements with full SpdxId and CreationInfo are returned unchanged.
 2. Run `expand-payload.py` to create corresponding "element" .json files in directory "out"
 
 This code assumes that the payload is correct. Production code would check for payload errors and handle them properly.
+
+## Use Cases
+1. Single payload with five elements: `payload_simple_acme.json`
+2. Two payloads: `payload_simple_acme_A.json` imports two elements from `payload_simple_acme_B.json`
+using an SpdxDocument element for payload B.

--- a/implementations/2/payload_simple_acme_A.json
+++ b/implementations/2/payload_simple_acme_A.json
@@ -1,0 +1,58 @@
+{
+  "creationInfoMap": {
+    "": {
+      "specVersion": "3.0.0",
+      "created": "2023-07-21T15:57:00Z",
+      "createdBy": [
+        "urn:jane-doe-1@acme.com-76010e36-20e3-11ee-be56-0242ac120002",
+        "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002"
+      ],
+      "profile": [
+        "Core",
+        "Software"
+      ],
+      "dataLicense": "CC0-1.0",
+      "createdUsing": []
+    }
+  },
+  "element": [
+    {
+      "spdxId": "urn:sbom-acme-application-8f833b36-20e3-11ee-be56-0242ac120002",
+      "type": "Sbom",
+      "element": [
+        "urn:product-acme-application-1.3-8f833b36-20e3-11ee-be56-0242ac120002",
+        "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002",
+        "urn:jane-doe-1@acme.com-76010e36-20e3-11ee-be56-0242ac120002",
+        "urn:relationship-acme-app-8f833b36-20e3-11ee-be56-0242ac120002"
+      ],
+      "rootElement": [
+        "urn:product-acme-application-1.3-8f833b36-20e3-11ee-be56-0242ac120002"
+      ],
+      "name": "acme-application"
+    },
+    {
+      "spdxId": "urn:product-acme-application-1.3-8f833b36-20e3-11ee-be56-0242ac120002",
+      "type": "Package",
+      "name": "acme-application"
+    },
+    {
+      "spdxId": "urn:relationship-acme-app-8f833b36-20e3-11ee-be56-0242ac120002",
+      "type": "Relationship",
+      "from": "urn:product-acme-application-1.3-8f833b36-20e3-11ee-be56-0242ac120002",
+      "relationshipType": "availableFrom",
+      "to": [
+        "urn:jane-doe-1@acme.com-76010e36-20e3-11ee-be56-0242ac120002",
+        "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002"
+      ]
+    },
+    {
+      "spdxId": "urn:people-acme-app-bca91b23-bf7d-4a97-83db-d6f08fd4a5d0",
+      "type": "SpdxDocument",
+      "element": [
+        "urn:jane-doe-1@acme.com-76010e36-20e3-11ee-be56-0242ac120002",
+        "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002"
+      ],
+      "locationHint": "https://sboms.acme.com/payload_simple_acme_B.json"
+    }
+  ]
+}

--- a/implementations/2/payload_simple_acme_B.json
+++ b/implementations/2/payload_simple_acme_B.json
@@ -1,0 +1,28 @@
+{
+  "creationInfoMap": {
+    "": {
+      "specVersion": "3.0.0",
+      "created": "2023-07-21T15:57:00Z",
+      "createdBy": [
+        "urn:jane-doe-1@acme.com-76010e36-20e3-11ee-be56-0242ac120002",
+        "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002"
+      ],
+      "profile": [
+        "Core",
+        "Software"
+      ],
+      "dataLicense": "CC0-1.0",
+      "createdUsing": []
+    }
+  },
+  "element": [
+    {
+      "spdxId": "urn:jane-doe-1@acme.com-76010e36-20e3-11ee-be56-0242ac120002",
+      "type": "Person"
+    },
+    {
+      "spdxId": "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002",
+      "type": "Agent"
+    }
+  ]
+}


### PR DESCRIPTION
Splits five acme-simple elements across two payloads, moving two elements from payload A to payload B, and adding SpdxDocument to A to reference the two elements in B.