### PR TITLE
jsonld: Add proposed "lite" schema

### DIFF
--- a/jsonld/examples/lite.json
+++ b/jsonld/examples/lite.json
@@ -1,0 +1,73 @@
+{
+    "@context": "https://raw.githubusercontent.com/spdx/spdx-3-serialization-prototype-playground/main/jsonld/spdx-3.0-context.json-ld",
+    "type": "SpdxDocument",
+    "spdxId": "http://spdx.example.org/Document",
+    "creationInfo": {
+        "type": "CreationInfo",
+        "id": "_:creationinfo",
+        "createdBy": [{
+            "type": "Person",
+            "spdxId": "http://spdx.example.com/Agent/JoshuaWatt",
+            "name": "Joshua Watt",
+            "creationInfo": "_:creationinfo"
+        }],
+        "specVersion": "3.0.0",
+        "created": "2024-03-06T00:00:00Z"
+    },
+    "profileConformance": [
+        "core",
+        "software"
+    ],
+    "rootElement": [
+        "http://spdx.example.com/BOM1"
+    ],
+    "element": [
+        {
+            "type": "software_Sbom",
+            "spdxId": "http://spdx.example.com/BOM1",
+            "creationInfo": "_:creationinfo",
+            "rootElement": [
+                "http://spdx.example.com/Package1"
+            ],
+            "software_sbomType": ["build"]
+        },
+        {
+            "type": "software_Package",
+            "spdxId": "http://spdx.example.com/Package1",
+            "creationInfo": "_:creationinfo",
+            "name": "my-package",
+            "software_packageVersion": "1.0",
+            "software_downloadLocation": "http://dl.example.com/my-package_1.0.0.tar",
+            "builtTime": "2024-03-06T00:00:00Z",
+            "originatedBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ]
+        },
+        {
+            "type": "software_File",
+            "spdxId": "http://spdx.example.com/Package1/myprogram",
+            "creationInfo": "_:creationinfo",
+            "name": "myprogram",
+            "software_primaryPurpose": "executable",
+            "software_additionalPurpose": [
+                "application"
+            ],
+            "software_copyrightText": "Copyright 2024, Joshua Watt",
+            "builtTime": "2024-03-06T00:00:00Z",
+            "originatedBy": [
+                "http://spdx.example.com/Agent/JoshuaWatt"
+            ]
+        },
+        {
+            "type": "Relationship",
+            "spdxId": "http://spdx.example.com/Relationship/1",
+            "creationInfo": "_:creationinfo",
+            "from": "http://spdx.example.com/Package1",
+            "relationshipType": "contains",
+            "to": [
+                "http://spdx.example.com/Package1/myprogram"
+            ],
+            "completeness": "complete"
+        }
+    ]
+}

--- a/jsonld/spdx-3.0-lite-schema.json
+++ b/jsonld/spdx-3.0-lite-schema.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$comment": "SPDX 'lite' schema. The schema forces the root object to be an SpdxDocument instead of using '@graph', and elements are generally inlined where possible instead of using references, but otherwise is fully valid JSON-LD (and still conforms to the main SPDX schema",
+    "type": "object",
+
+    "allOf": [
+        {
+            "properties": {
+                "@context": {
+                    "const": "https://raw.githubusercontent.com/spdx/spdx-3-serialization-prototype-playground/main/jsonld/spdx-3.0-context.json-ld"
+                }
+            },
+            "required": ["@context"]
+        },
+        {
+            "$ref": "https://raw.githubusercontent.com/spdx/spdx-3-serialization-prototype-playground/main/jsonld/spdx-3.0-schema.json#/$defs/SpdxDocument"
+        }
+    ],
+    "unevaluatedProperties": false
+}


### PR DESCRIPTION
Adds a proposed method for implementing a "lite" JSON-LD SPDX format. Instead of re-specifying the spec, the lite profile is instead a small hand-curated JSON schema that simply forces the root object of the document to be a SpdxDocument. This works fine because the SpdxDocument is already supposed to encompass the document elements in its elements array, so inlining them makes sense anyway.

This means that the "lite" document is also completely valid JSON-LD, which means it can be validated by the SHACL model, or even the full JSON-LD schema.

It also means it automatically keeps up with the main schema document when it changes