### PR TITLE
jsonld: README: Do not cache schema

### DIFF
--- a/jsonld/README.md
+++ b/jsonld/README.md
@@ -27,6 +27,7 @@ For example, to use the Python `check-jsonschema` package, use:
 ```shell
 check-jsonschema \
     -v --traceback-mode full \
+    --no-cache \
     --schemafile https://raw.githubusercontent.com/spdx/spdx-3-serialization-prototype-playground/main/jsonld/spdx-3.0-schema.json \
     <FILE_TO_CHECK>
 ```


### PR DESCRIPTION
Modify the validation instructions to not cache the schema as it has changed and caching will result in invalid results